### PR TITLE
borders in the sideBarSections and terminal split more visible

### DIFF
--- a/src/moonlight-ii-italic.json
+++ b/src/moonlight-ii-italic.json
@@ -76,7 +76,7 @@
     "titleBar.border": "--moonlight-gray-2",
     "sideBarTitle.foreground": "--moonlight-gray-10",
     "sideBarSectionHeader.background": "--moonlight-gray-3",
-    "sideBarSectionHeader.border": "--moonlight-gray-460",
+    "sideBarSectionHeader.border": "--moonlight-gray-5",
     "input.background": "--moonlight-gray-2",
     "input.foreground": "--moonlight-gray-10",
     "input.placeholderForeground": "--moonlight-gray-10aa",
@@ -121,6 +121,7 @@
     "terminal.ansiBrightMagenta": "--moonlight-pink",
     "terminal.ansiBrightRed": "--moonlight-red",
     "terminal.ansiBrightYellow": "--moonlight-yellow",
+    "terminal.border": "--moonlight-gray-5",
     "scrollbarSlider.background": "--moonlight-gray-730",
     "scrollbarSlider.hoverBackground": "--moonlight-gray-830",
     "scrollbarSlider.activeBackground": "--moonlight-blue",
@@ -207,11 +208,7 @@
   "tokenColors": [
     {
       "name": "Comment",
-      "scope": [
-        "comment",
-        "punctuation.definition.comment",
-        "string.quoted.docstring"
-      ],
+      "scope": ["comment", "punctuation.definition.comment", "string.quoted.docstring"],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-indigo"
@@ -219,12 +216,7 @@
     },
     {
       "name": "Variables and Plain Text",
-      "scope": [
-        "variable",
-        "support.variable",
-        "string constant.other.placeholder",
-        "text.html"
-      ],
+      "scope": ["variable", "support.variable", "string constant.other.placeholder", "text.html"],
       "settings": {
         "foreground": "--moonlight-gray-10"
       }
@@ -279,12 +271,7 @@
     },
     {
       "name": "Keyword, Storage",
-      "scope": [
-        "keyword",
-        "storage.type",
-        "storage.modifier",
-        "keyword.other.important"
-      ],
+      "scope": ["keyword", "storage.type", "storage.modifier", "keyword.other.important"],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -298,10 +285,7 @@
     },
     {
       "name": "Interpolation",
-      "scope": [
-        "punctuation.definition.template-expression",
-        "punctuation.section.embedded"
-      ],
+      "scope": ["punctuation.definition.template-expression", "punctuation.section.embedded"],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
@@ -359,11 +343,7 @@
     },
     {
       "name": "Function, Special Method",
-      "scope": [
-        "entity.name.function",
-        "variable.function",
-        "keyword.other.special-method"
-      ],
+      "scope": ["entity.name.function", "variable.function", "keyword.other.special-method"],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -501,11 +481,7 @@
     },
     {
       "name": "Types Fixes",
-      "scope": [
-        "source.haskell storage.type",
-        "source.c storage.type",
-        "source.java storage.type"
-      ],
+      "scope": ["source.haskell storage.type", "source.c storage.type", "source.java storage.type"],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
@@ -565,11 +541,7 @@
     },
     {
       "name": "Sub-methods",
-      "scope": [
-        "entity.name.module.js",
-        "variable.import.parameter.js",
-        "variable.other.class.js"
-      ],
+      "scope": ["entity.name.module.js", "variable.import.parameter.js", "variable.other.class.js"],
       "settings": {
         "foreground": "--moonlight-red"
       }
@@ -592,10 +564,7 @@
     },
     {
       "name": "meta.method.js",
-      "scope": [
-        "meta.class-method.js entity.name.function.js",
-        "variable.function.constructor"
-      ],
+      "scope": ["meta.class-method.js entity.name.function.js", "variable.function.constructor"],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -697,10 +666,7 @@
     },
     {
       "name": "Regular Expressions - Character Class",
-      "scope": [
-        "constant.other.character-class.regexp",
-        "keyword.control.anchor.regexp"
-      ],
+      "scope": ["constant.other.character-class.regexp", "keyword.control.anchor.regexp"],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -753,9 +719,7 @@
     },
     {
       "name": "ES7 Bind Operator",
-      "scope": [
-        "source.js constant.other.object.key.js string.unquoted.label.js"
-      ],
+      "scope": ["source.js constant.other.object.key.js string.unquoted.label.js"],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-red"
@@ -763,9 +727,7 @@
     },
     {
       "name": "JSON Key - Level 0",
-      "scope": [
-        "source.json meta.structure.dictionary.json support.type.property-name.json"
-      ],
+      "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -961,10 +923,7 @@
     },
     {
       "name": "Markdown - Fenced Bode Block Variable",
-      "scope": [
-        "markup.fenced_code.block.markdown",
-        "markup.inline.raw.string.markdown"
-      ],
+      "scope": ["markup.fenced_code.block.markdown", "markup.inline.raw.string.markdown"],
       "settings": {
         "foreground": "--moonlight-cyan"
       }

--- a/src/moonlight-ii.json
+++ b/src/moonlight-ii.json
@@ -76,7 +76,7 @@
     "titleBar.border": "--moonlight-gray-2",
     "sideBarTitle.foreground": "--moonlight-gray-10",
     "sideBarSectionHeader.background": "--moonlight-gray-3",
-    "sideBarSectionHeader.border": "--moonlight-gray-460",
+    "sideBarSectionHeader.border": "--moonlight-gray-5",
     "input.background": "--moonlight-gray-2",
     "input.foreground": "--moonlight-gray-10",
     "input.placeholderForeground": "--moonlight-gray-10aa",
@@ -121,6 +121,7 @@
     "terminal.ansiBrightMagenta": "--moonlight-pink",
     "terminal.ansiBrightRed": "--moonlight-red",
     "terminal.ansiBrightYellow": "--moonlight-yellow",
+    "terminal.border": "--moonlight-gray-5",
     "scrollbarSlider.background": "--moonlight-gray-730",
     "scrollbarSlider.hoverBackground": "--moonlight-gray-830",
     "scrollbarSlider.activeBackground": "--moonlight-blue",
@@ -207,23 +208,14 @@
   "tokenColors": [
     {
       "name": "Comment",
-      "scope": [
-        "comment",
-        "punctuation.definition.comment",
-        "string.quoted.docstring"
-      ],
+      "scope": ["comment", "punctuation.definition.comment", "string.quoted.docstring"],
       "settings": {
         "foreground": "--moonlight-indigo"
       }
     },
     {
       "name": "Variables and Plain Text",
-      "scope": [
-        "variable",
-        "support.variable",
-        "string constant.other.placeholder",
-        "text.html"
-      ],
+      "scope": ["variable", "support.variable", "string constant.other.placeholder", "text.html"],
       "settings": {
         "foreground": "--moonlight-gray-10"
       }
@@ -278,12 +270,7 @@
     },
     {
       "name": "Keyword, Storage",
-      "scope": [
-        "keyword",
-        "storage.type",
-        "storage.modifier",
-        "keyword.other.important"
-      ],
+      "scope": ["keyword", "storage.type", "storage.modifier", "keyword.other.important"],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -295,10 +282,7 @@
     },
     {
       "name": "Interpolation",
-      "scope": [
-        "punctuation.definition.template-expression",
-        "punctuation.section.embedded"
-      ],
+      "scope": ["punctuation.definition.template-expression", "punctuation.section.embedded"],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
@@ -354,11 +338,7 @@
     },
     {
       "name": "Function, Special Method",
-      "scope": [
-        "entity.name.function",
-        "variable.function",
-        "keyword.other.special-method"
-      ],
+      "scope": ["entity.name.function", "variable.function", "keyword.other.special-method"],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -496,11 +476,7 @@
     },
     {
       "name": "Types Fixes",
-      "scope": [
-        "source.haskell storage.type",
-        "source.c storage.type",
-        "source.java storage.type"
-      ],
+      "scope": ["source.haskell storage.type", "source.c storage.type", "source.java storage.type"],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
@@ -553,11 +529,7 @@
     },
     {
       "name": "Sub-methods",
-      "scope": [
-        "entity.name.module.js",
-        "variable.import.parameter.js",
-        "variable.other.class.js"
-      ],
+      "scope": ["entity.name.module.js", "variable.import.parameter.js", "variable.other.class.js"],
       "settings": {
         "foreground": "--moonlight-red"
       }
@@ -578,10 +550,7 @@
     },
     {
       "name": "meta.method.js",
-      "scope": [
-        "meta.class-method.js entity.name.function.js",
-        "variable.function.constructor"
-      ],
+      "scope": ["meta.class-method.js entity.name.function.js", "variable.function.constructor"],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -681,10 +650,7 @@
     },
     {
       "name": "Regular Expressions - Character Class",
-      "scope": [
-        "constant.other.character-class.regexp",
-        "keyword.control.anchor.regexp"
-      ],
+      "scope": ["constant.other.character-class.regexp", "keyword.control.anchor.regexp"],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -736,18 +702,14 @@
     },
     {
       "name": "ES7 Bind Operator",
-      "scope": [
-        "source.js constant.other.object.key.js string.unquoted.label.js"
-      ],
+      "scope": ["source.js constant.other.object.key.js string.unquoted.label.js"],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "JSON Key - Level 0",
-      "scope": [
-        "source.json meta.structure.dictionary.json support.type.property-name.json"
-      ],
+      "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -943,10 +905,7 @@
     },
     {
       "name": "Markdown - Fenced Bode Block Variable",
-      "scope": [
-        "markup.fenced_code.block.markdown",
-        "markup.inline.raw.string.markdown"
-      ],
+      "scope": ["markup.fenced_code.block.markdown", "markup.inline.raw.string.markdown"],
       "settings": {
         "foreground": "--moonlight-cyan"
       }

--- a/src/moonlight-italic.json
+++ b/src/moonlight-italic.json
@@ -134,11 +134,7 @@
     },
     {
       "name": "Tag",
-      "scope": [
-        "entity.name.tag",
-        "meta.tag.sgml",
-        "markup.deleted.git_gutter"
-      ],
+      "scope": ["entity.name.tag", "meta.tag.sgml", "markup.deleted.git_gutter"],
       "settings": {
         "foreground": "#ff757f"
       }
@@ -192,32 +188,21 @@
     },
     {
       "name": "Object Literal Key",
-      "scope": [
-        "meta.object-literal.key",
-        "entity.name.label.js",
-        "string.unquoted"
-      ],
+      "scope": ["meta.object-literal.key", "entity.name.label.js", "string.unquoted"],
       "settings": {
         "foreground": "#c7f59b"
       }
     },
     {
       "name": "DOM",
-      "scope": [
-        "support.variable.dom",
-        "support.constant.json",
-        "support.constant.math"
-      ],
+      "scope": ["support.variable.dom", "support.constant.json", "support.constant.math"],
       "settings": {
         "foreground": "#ffdb8e"
       }
     },
     {
       "name": "Node",
-      "scope": [
-        "support.variable.object.node",
-        "support.variable.object.process"
-      ],
+      "scope": ["support.variable.object.node", "support.variable.object.process"],
       "settings": {
         "foreground": "#ffd88c"
       }
@@ -231,12 +216,7 @@
     },
     {
       "name": "Constant, Function Argument, Tag Attribute, Embedded",
-      "scope": [
-        "constant.language",
-        "support.constant",
-        "constant.escape",
-        "keyword.other.unit"
-      ],
+      "scope": ["constant.language", "support.constant", "constant.escape", "keyword.other.unit"],
       "settings": {
         "foreground": "#ff8a8a"
       }
@@ -250,11 +230,7 @@
     },
     {
       "name": "Number",
-      "scope": [
-        "constant.numeric",
-        "constant.language.infinity",
-        "constant.language.nan"
-      ],
+      "scope": ["constant.numeric", "constant.language.infinity", "constant.language.nan"],
       "settings": {
         "foreground": "#ff9668"
       }
@@ -268,10 +244,7 @@
     },
     {
       "name": "Number, Constant, Function Argument, Tag Attribute, Embedded",
-      "scope": [
-        "variable.parameter.function.language.special",
-        "variable.parameter"
-      ],
+      "scope": ["variable.parameter.function.language.special", "variable.parameter"],
       "settings": {
         "foreground": "#f3c1ff"
       }
@@ -342,11 +315,7 @@
     },
     {
       "name": "Sub-methods",
-      "scope": [
-        "entity.name.module.js",
-        "variable.import.parameter.js",
-        "variable.other.class.js"
-      ],
+      "scope": ["entity.name.module.js", "variable.import.parameter.js", "variable.other.class.js"],
       "settings": {
         "foreground": "#FF5370"
       }
@@ -361,10 +330,7 @@
     },
     {
       "name": "meta.method.js",
-      "scope": [
-        "meta.class-method.js entity.name.function.js",
-        "variable.function.constructor"
-      ],
+      "scope": ["meta.class-method.js entity.name.function.js", "variable.function.constructor"],
       "settings": {
         "foreground": "#70b0ff"
       }
@@ -445,10 +411,7 @@
     },
     {
       "name": "CSS Keyframes Name",
-      "scope": [
-        "variable.parameter.keyframe-list",
-        "meta.at-rule.keyframes entity.name.function"
-      ],
+      "scope": ["variable.parameter.keyframe-list", "meta.at-rule.keyframes entity.name.function"],
       "settings": {
         "foreground": "#f989d3"
       }
@@ -553,9 +516,7 @@
     },
     {
       "name": "ES7 Bind Operator",
-      "scope": [
-        "source.js constant.other.object.key.js string.unquoted.label.js"
-      ],
+      "scope": ["source.js constant.other.object.key.js string.unquoted.label.js"],
       "settings": {
         "fontStyle": "italic",
         "foreground": "#FF5370"
@@ -563,9 +524,7 @@
     },
     {
       "name": "JSON Key - Level 0",
-      "scope": [
-        "source.json meta.structure.dictionary.json support.type.property-name.json"
-      ],
+      "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
         "foreground": "#70b0ff"
       }
@@ -757,10 +716,7 @@
     },
     {
       "name": "Markdown - Fenced Bode Block Variable",
-      "scope": [
-        "markup.fenced_code.block.markdown",
-        "markup.inline.raw.string.markdown"
-      ],
+      "scope": ["markup.fenced_code.block.markdown", "markup.inline.raw.string.markdown"],
       "settings": {
         "foreground": "#a7c6e8"
       }
@@ -855,7 +811,7 @@
     "titleBar.border": "#161a2a",
     "sideBarTitle.foreground": "#aab3e5",
     "sideBarSectionHeader.background": "#1e2132",
-    "sideBarSectionHeader.border": "#21233760",
+    "sideBarSectionHeader.border": "#aab3e520",
     "input.background": "#191a2a",
     "input.foreground": "#e4f3fa",
     "input.focus": "#34d3fb",
@@ -898,6 +854,7 @@
     "terminal.ansiBrightMagenta": "#baacff",
     "terminal.ansiBrightRed": "#FF5370",
     "terminal.ansiBrightYellow": "#ffdb8e",
+    "terminal.border": "#aab3e520",
     "scrollbarSlider.background": "#aab3e520",
     "scrollbarSlider.hoverBackground": "#aab3e510",
     "scrollbarSlider.activeBackground": "#74a0f1",

--- a/src/moonlight.json
+++ b/src/moonlight.json
@@ -119,11 +119,7 @@
     },
     {
       "name": "Tag",
-      "scope": [
-        "entity.name.tag",
-        "meta.tag.sgml",
-        "markup.deleted.git_gutter"
-      ],
+      "scope": ["entity.name.tag", "meta.tag.sgml", "markup.deleted.git_gutter"],
       "settings": {
         "foreground": "#ff757f"
       }
@@ -177,32 +173,21 @@
     },
     {
       "name": "Object Literal Key",
-      "scope": [
-        "meta.object-literal.key",
-        "entity.name.label.js",
-        "string.unquoted"
-      ],
+      "scope": ["meta.object-literal.key", "entity.name.label.js", "string.unquoted"],
       "settings": {
         "foreground": "#c7f59b"
       }
     },
     {
       "name": "DOM",
-      "scope": [
-        "support.variable.dom",
-        "support.constant.json",
-        "support.constant.math"
-      ],
+      "scope": ["support.variable.dom", "support.constant.json", "support.constant.math"],
       "settings": {
         "foreground": "#ffdb8e"
       }
     },
     {
       "name": "Node",
-      "scope": [
-        "support.variable.object.node",
-        "support.variable.object.process"
-      ],
+      "scope": ["support.variable.object.node", "support.variable.object.process"],
       "settings": {
         "foreground": "#ffd88c"
       }
@@ -216,12 +201,7 @@
     },
     {
       "name": "Constant, Function Argument, Tag Attribute, Embedded",
-      "scope": [
-        "constant.language",
-        "support.constant",
-        "constant.escape",
-        "keyword.other.unit"
-      ],
+      "scope": ["constant.language", "support.constant", "constant.escape", "keyword.other.unit"],
       "settings": {
         "foreground": "#ff8a8a"
       }
@@ -235,11 +215,7 @@
     },
     {
       "name": "Number",
-      "scope": [
-        "constant.numeric",
-        "constant.language.infinity",
-        "constant.language.nan"
-      ],
+      "scope": ["constant.numeric", "constant.language.infinity", "constant.language.nan"],
       "settings": {
         "foreground": "#ff9668"
       }
@@ -253,10 +229,7 @@
     },
     {
       "name": "Number, Constant, Function Argument, Tag Attribute, Embedded",
-      "scope": [
-        "variable.parameter.function.language.special",
-        "variable.parameter"
-      ],
+      "scope": ["variable.parameter.function.language.special", "variable.parameter"],
       "settings": {
         "foreground": "#f3c1ff"
       }
@@ -327,11 +300,7 @@
     },
     {
       "name": "Sub-methods",
-      "scope": [
-        "entity.name.module.js",
-        "variable.import.parameter.js",
-        "variable.other.class.js"
-      ],
+      "scope": ["entity.name.module.js", "variable.import.parameter.js", "variable.other.class.js"],
       "settings": {
         "foreground": "#FF5370"
       }
@@ -345,10 +314,7 @@
     },
     {
       "name": "meta.method.js",
-      "scope": [
-        "meta.class-method.js entity.name.function.js",
-        "variable.function.constructor"
-      ],
+      "scope": ["meta.class-method.js entity.name.function.js", "variable.function.constructor"],
       "settings": {
         "foreground": "#70b0ff"
       }
@@ -427,10 +393,7 @@
     },
     {
       "name": "CSS Keyframes Name",
-      "scope": [
-        "variable.parameter.keyframe-list",
-        "meta.at-rule.keyframes entity.name.function"
-      ],
+      "scope": ["variable.parameter.keyframe-list", "meta.at-rule.keyframes entity.name.function"],
       "settings": {
         "foreground": "#f989d3"
       }
@@ -534,18 +497,14 @@
     },
     {
       "name": "ES7 Bind Operator",
-      "scope": [
-        "source.js constant.other.object.key.js string.unquoted.label.js"
-      ],
+      "scope": ["source.js constant.other.object.key.js string.unquoted.label.js"],
       "settings": {
         "foreground": "#FF5370"
       }
     },
     {
       "name": "JSON Key - Level 0",
-      "scope": [
-        "source.json meta.structure.dictionary.json support.type.property-name.json"
-      ],
+      "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
       "settings": {
         "foreground": "#70b0ff"
       }
@@ -737,10 +696,7 @@
     },
     {
       "name": "Markdown - Fenced Bode Block Variable",
-      "scope": [
-        "markup.fenced_code.block.markdown",
-        "markup.inline.raw.string.markdown"
-      ],
+      "scope": ["markup.fenced_code.block.markdown", "markup.inline.raw.string.markdown"],
       "settings": {
         "foreground": "#a7c6e8"
       }
@@ -835,7 +791,7 @@
     "titleBar.border": "#161a2a",
     "sideBarTitle.foreground": "#aab3e5",
     "sideBarSectionHeader.background": "#1e2132",
-    "sideBarSectionHeader.border": "#21233760",
+    "sideBarSectionHeader.border": "#aab3e520",
     "input.background": "#191a2a",
     "input.foreground": "#e4f3fa",
     "input.focus": "#34d3fb",
@@ -878,6 +834,7 @@
     "terminal.ansiBrightMagenta": "#baacff",
     "terminal.ansiBrightRed": "#FF5370",
     "terminal.ansiBrightYellow": "#ffdb8e",
+    "terminal.border": "#aab3e520",
     "scrollbarSlider.background": "#aab3e520",
     "scrollbarSlider.hoverBackground": "#aab3e510",
     "scrollbarSlider.activeBackground": "#74a0f1",


### PR DESCRIPTION
This is the solution for #31 

<img width="831" alt="Screenshot 2022-01-05 at 10 03 01" src="https://user-images.githubusercontent.com/53769763/148190287-5f4bcd48-37d4-4cbf-9784-60f99c696d81.png">


Sorry for the formatting of some lines, it was done automatically. 