### PR TITLE
Added semantic colors for Go

### DIFF
--- a/src/moonlight-ii-italic.json
+++ b/src/moonlight-ii-italic.json
@@ -208,7 +208,11 @@
   "tokenColors": [
     {
       "name": "Comment",
-      "scope": ["comment", "punctuation.definition.comment", "string.quoted.docstring"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment",
+        "string.quoted.docstring"
+      ],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-indigo"
@@ -216,7 +220,12 @@
     },
     {
       "name": "Variables and Plain Text",
-      "scope": ["variable", "support.variable", "string constant.other.placeholder", "text.html"],
+      "scope": [
+        "variable",
+        "support.variable",
+        "string constant.other.placeholder",
+        "text.html"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-10"
       }
@@ -236,63 +245,89 @@
     },
     {
       "name": "Nil",
-      "scope": ["constant.language.undefined", "constant.language.null"],
+      "scope": [
+        "constant.language.undefined",
+        "constant.language.null"
+      ],
       "settings": {
         "foreground": "--moonlight-desaturated-gray"
       }
     },
     {
       "name": "PHP Constants",
-      "scope": ["constant.other.php"],
+      "scope": [
+        "constant.other.php"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Colors",
-      "scope": ["constant.other.color"],
+      "scope": [
+        "constant.other.color"
+      ],
       "settings": {
         "foreground": "#ffffff"
       }
     },
     {
       "name": "Invalid",
-      "scope": ["invalid", "invalid.illegal"],
+      "scope": [
+        "invalid",
+        "invalid.illegal"
+      ],
       "settings": {
         "foreground": "--moonlight-dark-red"
       }
     },
     {
       "name": "Invalid deprecated",
-      "scope": ["invalid.deprecated"],
+      "scope": [
+        "invalid.deprecated"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Keyword, Storage",
-      "scope": ["keyword", "storage.type", "storage.modifier", "keyword.other.important"],
+      "scope": [
+        "keyword",
+        "storage.type",
+        "storage.modifier",
+        "keyword.other.important"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Keyword, Storage",
-      "scope": ["keyword.control", "storage"],
+      "scope": [
+        "keyword.control",
+        "storage"
+      ],
       "settings": {
         "fontStyle": "italic"
       }
     },
     {
       "name": "Interpolation",
-      "scope": ["punctuation.definition.template-expression", "punctuation.section.embedded"],
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.section.embedded"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Spread",
-      "scope": ["keyword.operator.spread", "keyword.operator.rest"],
+      "scope": [
+        "keyword.operator.spread",
+        "keyword.operator.rest"
+      ],
       "settings": {
         "foreground": "--moonlight-red",
         "fontStyle": "bold"
@@ -329,42 +364,74 @@
     },
     {
       "name": "Keyword Control",
-      "scope": ["keyword.control"],
+      "scope": [
+        "keyword.control"
+      ],
       "settings": {
         "fontStyle": "italic"
       }
     },
     {
+      "name": "Go package name",
+      "scope": "source.go entity.name.package",
+      "settings": {
+        "foreground": "--moonlight-gray-10"
+      }
+    },
+    {
+      "name": "Go package imports",
+      "scope": "source.go entity.name.import",
+      "settings": {
+        "foreground": "--moonlight-green"
+      }
+    },
+    {
       "name": "Tag",
-      "scope": ["entity.name.tag", "meta.tag", "markup.deleted.git_gutter"],
+      "scope": [
+        "entity.name.tag",
+        "meta.tag",
+        "markup.deleted.git_gutter"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Function, Special Method",
-      "scope": ["entity.name.function", "variable.function", "keyword.other.special-method"],
+      "scope": [
+        "entity.name.function",
+        "variable.function",
+        "keyword.other.special-method"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
     },
     {
       "name": "Support Function",
-      "scope": ["support.function", "meta.function-call entity.name.function"],
+      "scope": [
+        "support.function",
+        "meta.function-call entity.name.function"
+      ],
       "settings": {
         "foreground": "--moonlight-sky-blue"
       }
     },
     {
       "name": "C-related Block Level Variables",
-      "scope": ["source.cpp meta.block variable.other"],
+      "scope": [
+        "source.cpp meta.block variable.other"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Other Variable, String Link",
-      "scope": ["support.other.variable", "string.other.link"],
+      "scope": [
+        "support.other.variable",
+        "string.other.link"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
@@ -380,6 +447,44 @@
         "constant.character",
         "constant.escape",
         "keyword.other.unit"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
+      }
+    },
+    {
+      "name": "Go constant placeholder",
+      "scope": [
+        "source.go constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
+      }
+    },
+    {
+      "name": "Go language constant",
+      "scope": [
+        "source.go constant.language"
+      ],
+      "settings": {
+        "foreground": "--moonlight-purple"
+      }
+    },
+    {
+      "name": "Go types",
+      "scope": [
+        "source.go storage.type"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "--moonlight-teal"
+      }
+    },
+    {
+      "name": "Go variable declaration and assignment",
+      "scope": [
+        "source.go variable.other.assignment",
+        "source.go variable.other.declaration"
       ],
       "settings": {
         "foreground": "--moonlight-light-red"
@@ -428,7 +533,9 @@
     },
     {
       "name": "Object",
-      "scope": ["variable.other.object"],
+      "scope": [
+        "variable.other.object"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
@@ -449,7 +556,10 @@
     },
     {
       "name": "Nested Object Property",
-      "scope": ["meta.object.member", "variable.other.object.property"],
+      "scope": [
+        "meta.object.member",
+        "variable.other.object.property"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-8"
       }
@@ -467,28 +577,38 @@
     },
     {
       "name": "Haskell Constants",
-      "scope": ["source.haskell constant.other.haskell"],
+      "scope": [
+        "source.haskell constant.other.haskell"
+      ],
       "settings": {
         "foreground": "--moonlight-light-red"
       }
     },
     {
       "name": "Haskell Imports",
-      "scope": ["source.haskell meta.import.haskell entity.name.namespace"],
+      "scope": [
+        "source.haskell meta.import.haskell entity.name.namespace"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-10"
       }
     },
     {
       "name": "Types Fixes",
-      "scope": ["source.haskell storage.type", "source.c storage.type", "source.java storage.type"],
+      "scope": [
+        "source.haskell storage.type",
+        "source.c storage.type",
+        "source.java storage.type"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Lambda Arrow",
-      "scope": ["storage.type.function"],
+      "scope": [
+        "storage.type.function"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -511,7 +631,9 @@
     },
     {
       "name": "Entity types",
-      "scope": ["support.type"],
+      "scope": [
+        "support.type"
+      ],
       "settings": {
         "foreground": "--moonlight-orange"
       }
@@ -534,21 +656,29 @@
     },
     {
       "name": "CSS value",
-      "scope": ["support.constant.property-value"],
+      "scope": [
+        "support.constant.property-value"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Sub-methods",
-      "scope": ["entity.name.module.js", "variable.import.parameter.js", "variable.other.class.js"],
+      "scope": [
+        "entity.name.module.js",
+        "variable.import.parameter.js",
+        "variable.other.class.js"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Language methods",
-      "scope": ["variable.language"],
+      "scope": [
+        "variable.language"
+      ],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-red"
@@ -556,7 +686,9 @@
     },
     {
       "name": "entity.name.method.js",
-      "scope": ["entity.name.method.js"],
+      "scope": [
+        "entity.name.method.js"
+      ],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-blue"
@@ -564,14 +696,19 @@
     },
     {
       "name": "meta.method.js",
-      "scope": ["meta.class-method.js entity.name.function.js", "variable.function.constructor"],
+      "scope": [
+        "meta.class-method.js entity.name.function.js",
+        "variable.function.constructor"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name"],
+      "scope": [
+        "entity.other.attribute-name"
+      ],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-purple"
@@ -600,14 +737,18 @@
     },
     {
       "name": "CSS Classes",
-      "scope": ["entity.other.attribute-name.class"],
+      "scope": [
+        "entity.other.attribute-name.class"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "CSS ID's",
-      "scope": ["source.sass keyword.control"],
+      "scope": [
+        "source.sass keyword.control"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -624,77 +765,102 @@
     },
     {
       "name": "CSS Property value",
-      "scope": ["support.constant.property-value"],
+      "scope": [
+        "support.constant.property-value"
+      ],
       "settings": {
         "foreground": "--moonlight-pink"
       }
     },
     {
       "name": "Inserted",
-      "scope": ["markup.inserted"],
+      "scope": [
+        "markup.inserted"
+      ],
       "settings": {
         "foreground": "--moonlight-green"
       }
     },
     {
       "name": "Deleted",
-      "scope": ["markup.deleted"],
+      "scope": [
+        "markup.deleted"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Changed",
-      "scope": ["markup.changed"],
+      "scope": [
+        "markup.changed"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Regular Expressions",
-      "scope": ["string.regexp"],
+      "scope": [
+        "string.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-bright-cyan"
       }
     },
     {
       "name": "Regular Expressions - Punctuation",
-      "scope": ["punctuation.definition.group"],
+      "scope": [
+        "punctuation.definition.group"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Regular Expressions - Character Class",
-      "scope": ["constant.other.character-class.regexp", "keyword.control.anchor.regexp"],
+      "scope": [
+        "constant.other.character-class.regexp",
+        "keyword.control.anchor.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Regular Expressions - Character Class Set",
-      "scope": ["constant.other.character-class.set.regexp"],
+      "scope": [
+        "constant.other.character-class.set.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Regular Expressions - Quantifier",
-      "scope": ["keyword.operator.quantifier.regexp"],
+      "scope": [
+        "keyword.operator.quantifier.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-pink"
       }
     },
     {
       "name": "Escape Characters",
-      "scope": ["constant.character.escape"],
+      "scope": [
+        "constant.character.escape"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "URL",
-      "scope": ["*url*", "*link*", "*uri*"],
+      "scope": [
+        "*url*",
+        "*link*",
+        "*uri*"
+      ],
       "settings": {
         "fontStyle": "underline"
       }
@@ -712,14 +878,18 @@
     },
     {
       "name": "CSS Units",
-      "scope": ["keyword.other.unit"],
+      "scope": [
+        "keyword.other.unit"
+      ],
       "settings": {
         "foreground": "--moonlight-dark-orange"
       }
     },
     {
       "name": "ES7 Bind Operator",
-      "scope": ["source.js constant.other.object.key.js string.unquoted.label.js"],
+      "scope": [
+        "source.js constant.other.object.key.js string.unquoted.label.js"
+      ],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-red"
@@ -727,7 +897,9 @@
     },
     {
       "name": "JSON Key - Level 0",
-      "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+      "scope": [
+        "source.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -788,7 +960,9 @@
     },
     {
       "name": "Plain Punctuation",
-      "scope": ["punctuation.definition.list_item.markdown"],
+      "scope": [
+        "punctuation.definition.list_item.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-7"
       }
@@ -808,14 +982,19 @@
     },
     {
       "name": "Markdown - Plain",
-      "scope": ["meta.jsx.children", "meta.embedded.block"],
+      "scope": [
+        "meta.jsx.children",
+        "meta.embedded.block"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-9"
       }
     },
     {
       "name": "Markdown - Markup Raw Inline",
-      "scope": ["text.html.markdown markup.inline.raw.markdown"],
+      "scope": [
+        "text.html.markdown markup.inline.raw.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -842,7 +1021,9 @@
     },
     {
       "name": "Markup - Italic",
-      "scope": ["markup.italic"],
+      "scope": [
+        "markup.italic"
+      ],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-red"
@@ -850,7 +1031,10 @@
     },
     {
       "name": "Markup - Bold",
-      "scope": ["markup.bold", "markup.bold string"],
+      "scope": [
+        "markup.bold",
+        "markup.bold string"
+      ],
       "settings": {
         "fontStyle": "bold",
         "foreground": "--moonlight-red"
@@ -873,7 +1057,9 @@
     },
     {
       "name": "Markup - Underline",
-      "scope": ["markup.underline"],
+      "scope": [
+        "markup.underline"
+      ],
       "settings": {
         "fontStyle": "underline",
         "foreground": "--moonlight-orange"
@@ -881,63 +1067,82 @@
     },
     {
       "name": "Markdown - Blockquote",
-      "scope": ["markup.quote punctuation.definition.blockquote.markdown"],
+      "scope": [
+        "markup.quote punctuation.definition.blockquote.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Markup - Quote",
-      "scope": ["markup.quote"],
+      "scope": [
+        "markup.quote"
+      ],
       "settings": {
         "fontStyle": "italic"
       }
     },
     {
       "name": "Markdown - Link",
-      "scope": ["string.other.link.title.markdown"],
+      "scope": [
+        "string.other.link.title.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
     },
     {
       "name": "Markdown - Link Description",
-      "scope": ["string.other.link.description.title.markdown"],
+      "scope": [
+        "string.other.link.description.title.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Markdown - Link Anchor",
-      "scope": ["constant.other.reference.link.markdown"],
+      "scope": [
+        "constant.other.reference.link.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Markup - Raw Block",
-      "scope": ["markup.raw.block"],
+      "scope": [
+        "markup.raw.block"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Markdown - Fenced Bode Block Variable",
-      "scope": ["markup.fenced_code.block.markdown", "markup.inline.raw.string.markdown"],
+      "scope": [
+        "markup.fenced_code.block.markdown",
+        "markup.inline.raw.string.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Markdown - Fenced Language",
-      "scope": ["variable.language.fenced.markdown"],
+      "scope": [
+        "variable.language.fenced.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Markdown - Separator",
-      "scope": ["meta.separator"],
+      "scope": [
+        "meta.separator"
+      ],
       "settings": {
         "fontStyle": "bold",
         "foreground": "--moonlight-cyan"
@@ -945,7 +1150,9 @@
     },
     {
       "name": "Markup - Table",
-      "scope": ["markup.table"],
+      "scope": [
+        "markup.table"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-7"
       }

--- a/src/moonlight-ii-italic.json
+++ b/src/moonlight-ii-italic.json
@@ -371,20 +371,7 @@
         "fontStyle": "italic"
       }
     },
-    {
-      "name": "Go package name",
-      "scope": "source.go entity.name.package",
-      "settings": {
-        "foreground": "--moonlight-gray-10"
-      }
-    },
-    {
-      "name": "Go package imports",
-      "scope": "source.go entity.name.import",
-      "settings": {
-        "foreground": "--moonlight-green"
-      }
-    },
+
     {
       "name": "Tag",
       "scope": [
@@ -452,44 +439,7 @@
         "foreground": "--moonlight-light-red"
       }
     },
-    {
-      "name": "Go constant placeholder",
-      "scope": [
-        "source.go constant.other.placeholder"
-      ],
-      "settings": {
-        "foreground": "--moonlight-light-red"
-      }
-    },
-    {
-      "name": "Go language constant",
-      "scope": [
-        "source.go constant.language"
-      ],
-      "settings": {
-        "foreground": "--moonlight-purple"
-      }
-    },
-    {
-      "name": "Go types",
-      "scope": [
-        "source.go storage.type"
-      ],
-      "settings": {
-        "fontStyle": "italic",
-        "foreground": "--moonlight-teal"
-      }
-    },
-    {
-      "name": "Go variable declaration and assignment",
-      "scope": [
-        "source.go variable.other.assignment",
-        "source.go variable.other.declaration"
-      ],
-      "settings": {
-        "foreground": "--moonlight-light-red"
-      }
-    },
+
     {
       "name": "Number, Boolean",
       "scope": [
@@ -1179,6 +1129,58 @@
       "scope": "token.debug-token",
       "settings": {
         "foreground": "--moonlight-purple"
+      }
+    },
+    {
+      "name": "Go package name",
+      "scope": "source.go entity.name.package",
+      "settings": {
+        "foreground": "--moonlight-gray-10"
+      }
+    },
+    {
+      "name": "Go package imports",
+      "scope": "source.go entity.name.import",
+      "settings": {
+        "foreground": "--moonlight-green"
+      }
+    },
+    {
+      "name": "Go constant placeholder",
+      "scope": [
+        "source.go constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
+      }
+    },
+    {
+      "name": "Go language constant",
+      "scope": [
+        "source.go constant.language"
+      ],
+      "settings": {
+        "foreground": "--moonlight-purple"
+      }
+    },
+    {
+      "name": "Go types",
+      "scope": [
+        "source.go storage.type"
+      ],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "--moonlight-teal"
+      }
+    },
+    {
+      "name": "Go variable declaration and assignment",
+      "scope": [
+        "source.go variable.other.assignment",
+        "source.go variable.other.declaration"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
       }
     }
   ]

--- a/src/moonlight-ii.json
+++ b/src/moonlight-ii.json
@@ -208,16 +208,34 @@
   "tokenColors": [
     {
       "name": "Comment",
-      "scope": ["comment", "punctuation.definition.comment", "string.quoted.docstring"],
+      "scope": [
+        "comment",
+        "punctuation.definition.comment",
+        "string.quoted.docstring"
+      ],
       "settings": {
         "foreground": "--moonlight-indigo"
       }
     },
     {
       "name": "Variables and Plain Text",
-      "scope": ["variable", "support.variable", "string constant.other.placeholder", "text.html"],
+      "scope": [
+        "variable",
+        "support.variable",
+        "string constant.other.placeholder",
+        "text.html"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-10"
+      }
+    },
+    {
+      "name": "Go constant placeholder",
+      "scope": [
+        "source.go constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
       }
     },
     {
@@ -235,61 +253,96 @@
     },
     {
       "name": "Nil",
-      "scope": ["constant.language.undefined", "constant.language.null"],
+      "scope": [
+        "constant.language.undefined",
+        "constant.language.null"
+      ],
       "settings": {
         "foreground": "--moonlight-desaturated-gray"
       }
     },
     {
+      "name": "Go language constants",
+      "scope": [
+        "source.go constant.language"
+      ],
+      "settings": {
+        "foreground": "--moonlight-purple"
+      }
+    },
+    {
       "name": "PHP Constants",
-      "scope": ["constant.other.php"],
+      "scope": [
+        "constant.other.php"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Colors",
-      "scope": ["constant.other.color"],
+      "scope": [
+        "constant.other.color"
+      ],
       "settings": {
         "foreground": "#ffffff"
       }
     },
     {
       "name": "Invalid",
-      "scope": ["invalid", "invalid.illegal"],
+      "scope": [
+        "invalid",
+        "invalid.illegal"
+      ],
       "settings": {
         "foreground": "--moonlight-dark-red"
       }
     },
     {
       "name": "Invalid deprecated",
-      "scope": ["invalid.deprecated"],
+      "scope": [
+        "invalid.deprecated"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Keyword, Storage",
-      "scope": ["keyword", "storage.type", "storage.modifier", "keyword.other.important"],
+      "scope": [
+        "keyword",
+        "storage.type",
+        "storage.modifier",
+        "keyword.other.important"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Keyword, Storage",
-      "scope": ["keyword.control", "storage"],
+      "scope": [
+        "keyword.control",
+        "storage"
+      ],
       "settings": {}
     },
     {
       "name": "Interpolation",
-      "scope": ["punctuation.definition.template-expression", "punctuation.section.embedded"],
+      "scope": [
+        "punctuation.definition.template-expression",
+        "punctuation.section.embedded"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Spread",
-      "scope": ["keyword.operator.spread", "keyword.operator.rest"],
+      "scope": [
+        "keyword.operator.spread",
+        "keyword.operator.rest"
+      ],
       "settings": {
         "foreground": "--moonlight-red",
         "fontStyle": "bold"
@@ -326,40 +379,72 @@
     },
     {
       "name": "Keyword Control",
-      "scope": ["keyword.control"],
+      "scope": [
+        "keyword.control"
+      ],
       "settings": {}
     },
     {
+      "name": "Go package name",
+      "scope": "source.go entity.name.package",
+      "settings": {
+        "foreground": "--moonlight-gray-10"
+      }
+    },
+    {
+      "name": "Go package imports",
+      "scope": "source.go entity.name.import",
+      "settings": {
+        "foreground": "--moonlight-green'"
+      }
+    },
+    {
       "name": "Tag",
-      "scope": ["entity.name.tag", "meta.tag", "markup.deleted.git_gutter"],
+      "scope": [
+        "entity.name.tag",
+        "meta.tag",
+        "markup.deleted.git_gutter"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Function, Special Method",
-      "scope": ["entity.name.function", "variable.function", "keyword.other.special-method"],
+      "scope": [
+        "entity.name.function",
+        "variable.function",
+        "keyword.other.special-method"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
     },
     {
       "name": "Support Function",
-      "scope": ["support.function", "meta.function-call entity.name.function"],
+      "scope": [
+        "support.function",
+        "meta.function-call entity.name.function"
+      ],
       "settings": {
         "foreground": "--moonlight-sky-blue"
       }
     },
     {
       "name": "C-related Block Level Variables",
-      "scope": ["source.cpp meta.block variable.other"],
+      "scope": [
+        "source.cpp meta.block variable.other"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Other Variable, String Link",
-      "scope": ["support.other.variable", "string.other.link"],
+      "scope": [
+        "support.other.variable",
+        "string.other.link"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
@@ -375,6 +460,25 @@
         "constant.character",
         "constant.escape",
         "keyword.other.unit"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
+      }
+    },
+    {
+      "name": "Go storage type",
+      "scope": [
+        "source.go storage.type"
+      ],
+      "settings": {
+        "foreground": "--moonlight-teal"
+      }
+    },
+    {
+      "name": "Go variable declaration and assignment",
+      "scope": [
+        "source.go variable.other.assignment",
+        "source.go variable.other.declaration"
       ],
       "settings": {
         "foreground": "--moonlight-light-red"
@@ -423,7 +527,9 @@
     },
     {
       "name": "Object",
-      "scope": ["variable.other.object"],
+      "scope": [
+        "variable.other.object"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
@@ -444,7 +550,10 @@
     },
     {
       "name": "Nested Object Property",
-      "scope": ["meta.object.member", "variable.other.object.property"],
+      "scope": [
+        "meta.object.member",
+        "variable.other.object.property"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-8"
       }
@@ -462,28 +571,38 @@
     },
     {
       "name": "Haskell Constants",
-      "scope": ["source.haskell constant.other.haskell"],
+      "scope": [
+        "source.haskell constant.other.haskell"
+      ],
       "settings": {
         "foreground": "--moonlight-light-red"
       }
     },
     {
       "name": "Haskell Imports",
-      "scope": ["source.haskell meta.import.haskell entity.name.namespace"],
+      "scope": [
+        "source.haskell meta.import.haskell entity.name.namespace"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-10"
       }
     },
     {
       "name": "Types Fixes",
-      "scope": ["source.haskell storage.type", "source.c storage.type", "source.java storage.type"],
+      "scope": [
+        "source.haskell storage.type",
+        "source.c storage.type",
+        "source.java storage.type"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Lambda Arrow",
-      "scope": ["storage.type.function"],
+      "scope": [
+        "storage.type.function"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -506,7 +625,9 @@
     },
     {
       "name": "Entity types",
-      "scope": ["support.type"],
+      "scope": [
+        "support.type"
+      ],
       "settings": {
         "foreground": "--moonlight-orange"
       }
@@ -529,35 +650,48 @@
     },
     {
       "name": "Sub-methods",
-      "scope": ["entity.name.module.js", "variable.import.parameter.js", "variable.other.class.js"],
+      "scope": [
+        "entity.name.module.js",
+        "variable.import.parameter.js",
+        "variable.other.class.js"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Language methods",
-      "scope": ["variable.language"],
+      "scope": [
+        "variable.language"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "entity.name.method.js",
-      "scope": ["entity.name.method.js"],
+      "scope": [
+        "entity.name.method.js"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
     },
     {
       "name": "meta.method.js",
-      "scope": ["meta.class-method.js entity.name.function.js", "variable.function.constructor"],
+      "scope": [
+        "meta.class-method.js entity.name.function.js",
+        "variable.function.constructor"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
     },
     {
       "name": "Attributes",
-      "scope": ["entity.other.attribute-name"],
+      "scope": [
+        "entity.other.attribute-name"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -584,14 +718,18 @@
     },
     {
       "name": "CSS Classes",
-      "scope": ["entity.other.attribute-name.class"],
+      "scope": [
+        "entity.other.attribute-name.class"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "CSS ID's",
-      "scope": ["source.sass keyword.control"],
+      "scope": [
+        "source.sass keyword.control"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -608,77 +746,102 @@
     },
     {
       "name": "CSS Property value",
-      "scope": ["support.constant.property-value"],
+      "scope": [
+        "support.constant.property-value"
+      ],
       "settings": {
         "foreground": "--moonlight-pink"
       }
     },
     {
       "name": "Inserted",
-      "scope": ["markup.inserted"],
+      "scope": [
+        "markup.inserted"
+      ],
       "settings": {
         "foreground": "--moonlight-green"
       }
     },
     {
       "name": "Deleted",
-      "scope": ["markup.deleted"],
+      "scope": [
+        "markup.deleted"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Changed",
-      "scope": ["markup.changed"],
+      "scope": [
+        "markup.changed"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Regular Expressions",
-      "scope": ["string.regexp"],
+      "scope": [
+        "string.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-bright-cyan"
       }
     },
     {
       "name": "Regular Expressions - Punctuation",
-      "scope": ["punctuation.definition.group"],
+      "scope": [
+        "punctuation.definition.group"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "Regular Expressions - Character Class",
-      "scope": ["constant.other.character-class.regexp", "keyword.control.anchor.regexp"],
+      "scope": [
+        "constant.other.character-class.regexp",
+        "keyword.control.anchor.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Regular Expressions - Character Class Set",
-      "scope": ["constant.other.character-class.set.regexp"],
+      "scope": [
+        "constant.other.character-class.set.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Regular Expressions - Quantifier",
-      "scope": ["keyword.operator.quantifier.regexp"],
+      "scope": [
+        "keyword.operator.quantifier.regexp"
+      ],
       "settings": {
         "foreground": "--moonlight-pink"
       }
     },
     {
       "name": "Escape Characters",
-      "scope": ["constant.character.escape"],
+      "scope": [
+        "constant.character.escape"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "URL",
-      "scope": ["*url*", "*link*", "*uri*"],
+      "scope": [
+        "*url*",
+        "*link*",
+        "*uri*"
+      ],
       "settings": {
         "fontStyle": "underline"
       }
@@ -695,21 +858,27 @@
     },
     {
       "name": "CSS Units",
-      "scope": ["keyword.other.unit"],
+      "scope": [
+        "keyword.other.unit"
+      ],
       "settings": {
         "foreground": "--moonlight-dark-orange"
       }
     },
     {
       "name": "ES7 Bind Operator",
-      "scope": ["source.js constant.other.object.key.js string.unquoted.label.js"],
+      "scope": [
+        "source.js constant.other.object.key.js string.unquoted.label.js"
+      ],
       "settings": {
         "foreground": "--moonlight-red"
       }
     },
     {
       "name": "JSON Key - Level 0",
-      "scope": ["source.json meta.structure.dictionary.json support.type.property-name.json"],
+      "scope": [
+        "source.json meta.structure.dictionary.json support.type.property-name.json"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
@@ -770,7 +939,9 @@
     },
     {
       "name": "Plain Punctuation",
-      "scope": ["punctuation.definition.list_item.markdown"],
+      "scope": [
+        "punctuation.definition.list_item.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-7"
       }
@@ -790,14 +961,19 @@
     },
     {
       "name": "Markdown - Plain",
-      "scope": ["meta.jsx.children", "meta.embedded.block"],
+      "scope": [
+        "meta.jsx.children",
+        "meta.embedded.block"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-9"
       }
     },
     {
       "name": "Markdown - Markup Raw Inline",
-      "scope": ["text.html.markdown markup.inline.raw.markdown"],
+      "scope": [
+        "text.html.markdown markup.inline.raw.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
@@ -824,7 +1000,9 @@
     },
     {
       "name": "Markup - Italic",
-      "scope": ["markup.italic"],
+      "scope": [
+        "markup.italic"
+      ],
       "settings": {
         "fontStyle": "italic",
         "foreground": "--moonlight-red"
@@ -832,7 +1010,10 @@
     },
     {
       "name": "Markup - Bold",
-      "scope": ["markup.bold", "markup.bold string"],
+      "scope": [
+        "markup.bold",
+        "markup.bold string"
+      ],
       "settings": {
         "fontStyle": "bold",
         "foreground": "--moonlight-red"
@@ -855,7 +1036,9 @@
     },
     {
       "name": "Markup - Underline",
-      "scope": ["markup.underline"],
+      "scope": [
+        "markup.underline"
+      ],
       "settings": {
         "fontStyle": "underline",
         "foreground": "--moonlight-orange"
@@ -863,63 +1046,82 @@
     },
     {
       "name": "Markdown - Blockquote",
-      "scope": ["markup.quote punctuation.definition.blockquote.markdown"],
+      "scope": [
+        "markup.quote punctuation.definition.blockquote.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Markup - Quote",
-      "scope": ["markup.quote"],
+      "scope": [
+        "markup.quote"
+      ],
       "settings": {
         "fontStyle": "italic"
       }
     },
     {
       "name": "Markdown - Link",
-      "scope": ["string.other.link.title.markdown"],
+      "scope": [
+        "string.other.link.title.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-blue"
       }
     },
     {
       "name": "Markdown - Link Description",
-      "scope": ["string.other.link.description.title.markdown"],
+      "scope": [
+        "string.other.link.description.title.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Markdown - Link Anchor",
-      "scope": ["constant.other.reference.link.markdown"],
+      "scope": [
+        "constant.other.reference.link.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-yellow"
       }
     },
     {
       "name": "Markup - Raw Block",
-      "scope": ["markup.raw.block"],
+      "scope": [
+        "markup.raw.block"
+      ],
       "settings": {
         "foreground": "--moonlight-purple"
       }
     },
     {
       "name": "Markdown - Fenced Bode Block Variable",
-      "scope": ["markup.fenced_code.block.markdown", "markup.inline.raw.string.markdown"],
+      "scope": [
+        "markup.fenced_code.block.markdown",
+        "markup.inline.raw.string.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Markdown - Fenced Language",
-      "scope": ["variable.language.fenced.markdown"],
+      "scope": [
+        "variable.language.fenced.markdown"
+      ],
       "settings": {
         "foreground": "--moonlight-cyan"
       }
     },
     {
       "name": "Markdown - Separator",
-      "scope": ["meta.separator"],
+      "scope": [
+        "meta.separator"
+      ],
       "settings": {
         "fontStyle": "bold",
         "foreground": "--moonlight-cyan"
@@ -927,7 +1129,9 @@
     },
     {
       "name": "Markup - Table",
-      "scope": ["markup.table"],
+      "scope": [
+        "markup.table"
+      ],
       "settings": {
         "foreground": "--moonlight-gray-7"
       }

--- a/src/moonlight-ii.json
+++ b/src/moonlight-ii.json
@@ -229,15 +229,7 @@
         "foreground": "--moonlight-gray-10"
       }
     },
-    {
-      "name": "Go constant placeholder",
-      "scope": [
-        "source.go constant.other.placeholder"
-      ],
-      "settings": {
-        "foreground": "--moonlight-light-red"
-      }
-    },
+
     {
       "name": "DOM Variables",
       "scope": [
@@ -261,15 +253,7 @@
         "foreground": "--moonlight-desaturated-gray"
       }
     },
-    {
-      "name": "Go language constants",
-      "scope": [
-        "source.go constant.language"
-      ],
-      "settings": {
-        "foreground": "--moonlight-purple"
-      }
-    },
+
     {
       "name": "PHP Constants",
       "scope": [
@@ -384,20 +368,7 @@
       ],
       "settings": {}
     },
-    {
-      "name": "Go package name",
-      "scope": "source.go entity.name.package",
-      "settings": {
-        "foreground": "--moonlight-gray-10"
-      }
-    },
-    {
-      "name": "Go package imports",
-      "scope": "source.go entity.name.import",
-      "settings": {
-        "foreground": "--moonlight-green'"
-      }
-    },
+
     {
       "name": "Tag",
       "scope": [
@@ -465,25 +436,7 @@
         "foreground": "--moonlight-light-red"
       }
     },
-    {
-      "name": "Go storage type",
-      "scope": [
-        "source.go storage.type"
-      ],
-      "settings": {
-        "foreground": "--moonlight-teal"
-      }
-    },
-    {
-      "name": "Go variable declaration and assignment",
-      "scope": [
-        "source.go variable.other.assignment",
-        "source.go variable.other.declaration"
-      ],
-      "settings": {
-        "foreground": "--moonlight-light-red"
-      }
-    },
+
     {
       "name": "Number, Boolean",
       "scope": [
@@ -1158,6 +1111,57 @@
       "scope": "token.debug-token",
       "settings": {
         "foreground": "--moonlight-purple"
+      }
+    },
+   {
+      "name": "Go package name",
+      "scope": "source.go entity.name.package",
+      "settings": {
+        "foreground": "--moonlight-gray-10"
+      }
+    },
+    {
+      "name": "Go package imports",
+      "scope": "source.go entity.name.import",
+      "settings": {
+        "foreground": "--moonlight-green"
+      }
+    },
+    {
+      "name": "Go constant placeholder",
+      "scope": [
+        "source.go constant.other.placeholder"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
+      }
+    },
+    {
+      "name": "Go language constant",
+      "scope": [
+        "source.go constant.language"
+      ],
+      "settings": {
+        "foreground": "--moonlight-purple"
+      }
+    },
+    {
+      "name": "Go types",
+      "scope": [
+        "source.go storage.type"
+      ],
+      "settings": {
+        "foreground": "--moonlight-teal"
+      }
+    },
+    {
+      "name": "Go variable declaration and assignment",
+      "scope": [
+        "source.go variable.other.assignment",
+        "source.go variable.other.declaration"
+      ],
+      "settings": {
+        "foreground": "--moonlight-light-red"
       }
     }
   ]


### PR DESCRIPTION
Finished the patch, but I don't know why, Prettier formatted the two files completely different(I don't know what to do about it).

Issue: https://github.com/atomiks/moonlight-vscode-theme/issues/36